### PR TITLE
Adds support to de-serialization of entando response with metaData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+
+.classpath
+.project
+.settings/

--- a/src/main/java/org/entando/web/response/RestResponse.java
+++ b/src/main/java/org/entando/web/response/RestResponse.java
@@ -8,6 +8,8 @@ import org.springframework.hateoas.ResourceSupport;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+
 @Getter@Setter
 @NoArgsConstructor
 public class RestResponse<T, M> extends ResourceSupport {
@@ -16,13 +18,23 @@ public class RestResponse<T, M> extends ResourceSupport {
     private M metadata;
     private List<RestError> errors = new ArrayList<>();
 
+    @JsonSetter("metaData")
+    public void setMetaData(M metadata) {
+        this.metadata = metadata;
+    }
+
+    @JsonSetter("metadata")
+    public void setMetadata(M metadata) {
+        this.metadata = metadata;
+    }
+
     public RestResponse(final T payload) {
         setPayload(payload);
     }
 
     public RestResponse(final T payload, final M metadata) {
         setPayload(payload);
-        setMetadata(metadata);
+        setMetaData(metadata);
     }
 
     public RestResponse(final T payload, final M metadata, final List<RestError> errors) {

--- a/src/main/java/org/entando/web/response/SimpleRestResponse.java
+++ b/src/main/java/org/entando/web/response/SimpleRestResponse.java
@@ -25,7 +25,7 @@ public class SimpleRestResponse<T> extends RestResponse<T, Map<String, Object>> 
     }
 
     private Map<String, Object> init() {
-        setMetadata(new HashMap<>());
+        setMetaData(new HashMap<>());
         return getMetadata();
     }
 


### PR DESCRIPTION
Entando5 response format uses as properties `payload`, `metaData` and `errors`. 
Currently the extracted object is using a `metadata` property and therefore de-serialization of an Entando5 response isn't happening correctly.

This update should solve the problem. Let me know if you want some tests